### PR TITLE
Afflictions do not decay over time

### DIFF
--- a/rulebook/src/rules/combat/acting-in-combat/actions.md
+++ b/rulebook/src/rules/combat/acting-in-combat/actions.md
@@ -95,9 +95,10 @@ Attacks that you dodge are treated as if the attacker missed.
 
 ### Treat (1 AP)
 
-Attempt to treat a creature within 1 tile’s injuries and ailments, curing a single ailment or mitigating a single affliction of your choice.
+Attempt to treat the maladies of a creature within a 1 tile range, curing a single ailment or mitigating a single affliction of your choice.
+You are always within range of yourself, and so can target yourself with this action.
 
-Select a ailment or affliction. If you succeed on a difficulty 10 Focus (Medicine) skill check, remove all stacks of the chosen ailment or half the stacks of the chosen affliction from them.
+Select a ailment or affliction. If you succeed on a difficulty 15 Focus (Medicine) skill check, remove all stacks of an ailment or half the stacks rounded up of an affliction of your choice from your target.
 
 ### Ward (1 AP)
 

--- a/rulebook/src/rules/combat/acting-in-combat/actions.md
+++ b/rulebook/src/rules/combat/acting-in-combat/actions.md
@@ -98,7 +98,7 @@ Attacks that you dodge are treated as if the attacker missed.
 Attempt to treat the maladies of a creature within a 1 tile range, curing a single ailment or mitigating a single affliction of your choice.
 You are always within range of yourself, and so can target yourself with this action.
 
-Select a ailment or affliction. If you succeed on a difficulty 15 Focus (Medicine) skill check, remove all stacks of an ailment or half the stacks rounded up of an affliction of your choice from your target.
+Select a ailment or affliction. If you succeed on a difficulty 10 Focus (Medicine) skill check, remove all stacks of an ailment or half the stacks rounded up of an affliction of your choice from your target. If your result was 15 or higher, remove all stacks of that affliction instead.
 
 ### Ward (1 AP)
 

--- a/rulebook/src/rules/combat/conditions/README.md
+++ b/rulebook/src/rules/combat/conditions/README.md
@@ -28,8 +28,10 @@ This leaves you with two options:
 
 </div>
 
-**Ailments** stack in duration. While you have at least one stack of a particular ailment, suffer its effects.
-At the end of each of your turns, remove one stack of each ailment you are suffering from.
+**Ailments** are impairing effects: they do not stack in duration or intensity, although you can suffer the effects of multiple ailments at once.
+At the start of each of your turns, cure all ailments that you are currently suffering from.
+
+Ailments can also be removed using the Treat action.
 
 **Statuses** are common special effects (such as being flying, prone or invisible), that do not follow the rules of either afflictions or ailments.
 They may be good or bad, and do not share a particular structure or mechanics. Their complete rules are listed here for easy reference.

--- a/rulebook/src/rules/combat/conditions/README.md
+++ b/rulebook/src/rules/combat/conditions/README.md
@@ -5,7 +5,9 @@ Conditions (including the number of stacks) are always public information.
 
 **Afflictions** persist between turns, dealing damage over time that **triggers** when a certain course of action is taken. Afflictions are applied in **stacks,** which build up as you apply more of them but reduce over time (or when they are treated in some way).
 The first time during your turn that their trigger occurs, you take damage equal to the number of stacks of that affliction that you have.
-At the end of each of your turns, reduce the number of stacks each affliction by one. Damage dealt by afflictions occurs after the triggering event is complete, which is important for combinations (such as the Treat action and rage) where the action taken mitigates their effects.
+Damage dealt by afflictions occurs after the triggering event is complete, which is important for combinations (such as the Treat action and rage) where the action taken mitigates their effects.
+
+Afflictions persist until the end of combat, but can be removed via the Treat action.
 
 <div class="infobox">
 

--- a/rulebook/src/rules/combat/conditions/README.md
+++ b/rulebook/src/rules/combat/conditions/README.md
@@ -28,10 +28,8 @@ This leaves you with two options:
 
 </div>
 
-**Ailments** are impairing effects: they do not stack in duration or intensity, although you can suffer the effects of multiple ailments at once.
-At the start of each of your turns, cure all ailments that you are currently suffering from.
-
-Ailments can also be removed using the Treat action.
+**Ailments** stack in duration. While you have at least one stack of a particular ailment, suffer its effects.
+At the end of each of your turns, remove one stack of each ailment you are suffering from.
 
 **Statuses** are common special effects (such as being flying, prone or invisible), that do not follow the rules of either afflictions or ailments.
 They may be good or bad, and do not share a particular structure or mechanics. Their complete rules are listed here for easy reference.


### PR DESCRIPTION
Fixes #99.

Motivation is simple: tracking afflictions is the single most frustrating chore in combat.

Swapping to a non-decaying mode + buffing Treat should produce a similarly balanced effect, with much less bookkeeping.

Split-affliction builds will be better for consistent damage, but single affliction builds will do better for locking out actions.

If tracking is still onerous after this, we can look at #143 as well.
